### PR TITLE
STAC-23267: get settings improvements

### DIFF
--- a/docs/settings_provider_extension.md
+++ b/docs/settings_provider_extension.md
@@ -1,13 +1,13 @@
 # Settings provider extension
-Provides the capability to retrieve internal SUSE Observability/Stackstate settings to components.
+Provides the capability to supply internal SUSE Observability/StackState settings to components.
 
 The settings provider can use either a file or Kafka topic as a source for the settings (based on the protocol defined in
 [stackstate-openapi](https://gitlab.com/stackvista/platform/stackstate-openapi/-/blob/master/spec_settings/openapi.yaml?ref_type=heads)).
 
 ## Run locally
 
-What the following setup achieves is the following:
-- OTel Collector with Extension consuming internal settings message from Kafka
+What the setup achieves is the following:
+- OTel Collector with Extension consuming internal settings messages from Kafka
 
 Follow the [install dependencies](../README.md#install-dependencies) section in the main README.
 
@@ -58,7 +58,7 @@ docker run --rm \
   --network="host" sts-opentelemetry-collector:latest --config /config.yaml
 ```
 
-**with file-based settings provider**
+**with file-based settings provider (remember to update the extension config)**
 ```shell
 docker run --rm \
   -p 4317:4317 -p 4318:4318 \
@@ -86,10 +86,10 @@ go run ./extension/settingsproviderextension/cmd/publish-snapshot/main.go localh
 ```
 
 In the terminal tab where the OTel collector container is running, you should see in the logs that the settings messages
-have been processed and added to the internal state of the Kafka settings provider. Along the lines of:
+have been processed and added to the internal state of the Kafka settings provider (if debug logging is enabled):
 ```shell
-2025-08-16T12:57:15.264Z        info    kafka/kafka_settings_provider.go:253    Received snapshot start.        {"kind": "extension", "name": "sts_settings_provider", "snapshotId": "36b6a4e1-1a44-42da-ac72-bd17cefbd4ee", "settingType": "OtelComponentMapping"}
-2025-08-16T12:57:15.264Z        info    kafka/kafka_settings_provider.go:298    Received snapshot stop. Processing complete snapshot.   {"kind": "extension", "name": "sts_settings_provider", "snapshotId": "36b6a4e1-1a44-42da-ac72-bd17cefbd4ee", "settingType": "OtelComponentMapping", "settingCount": 1}
+2025-08-16T12:57:15.264Z        debug    kafka/kafka_settings_provider.go:253    Received snapshot start.        {"kind": "extension", "name": "sts_settings_provider", "snapshotId": "36b6a4e1-1a44-42da-ac72-bd17cefbd4ee", "settingType": "OtelComponentMapping"}
+2025-08-16T12:57:15.264Z        debug    kafka/kafka_settings_provider.go:298    Received snapshot stop. Processing complete snapshot.   {"kind": "extension", "name": "sts_settings_provider", "snapshotId": "36b6a4e1-1a44-42da-ac72-bd17cefbd4ee", "settingType": "OtelComponentMapping", "settingCount": 1}
 ```
 
 ## Full config
@@ -125,6 +125,9 @@ exporters:
     verbosity: detailed
 
 service:
+  telemetry:
+    logs:
+      level: debug
   extensions: [ sts_settings_provider ]
   pipelines:
     traces:

--- a/extension/settingsproviderextension/api.go
+++ b/extension/settingsproviderextension/api.go
@@ -52,7 +52,7 @@ type InternalRawSettingsProvider interface {
 // Internally, it:
 //  1. Downcasts the provider to InternalRawSettingsProvider
 //  2. Calls the untyped UnsafeGetCurrentSettingsByType method
-//  3. Casts and copies the results into a type-safe []T slice
+//  3. Casts the results into a type-safe []T slice
 //
 // All StsSettingsProvider implementations must also implement InternalRawSettingsProvider
 // for this function to work.
@@ -68,5 +68,5 @@ func GetSettingsAs[T any](p StsSettingsProvider, typ stsSettingsModel.SettingTyp
 	if err != nil {
 		return nil, err
 	}
-	return stsSettingsCore.CastAndCopySlice[T](vals)
+	return stsSettingsCore.CastSlice[T](vals)
 }

--- a/extension/settingsproviderextension/api.go
+++ b/extension/settingsproviderextension/api.go
@@ -7,7 +7,21 @@ import (
 	"go.opentelemetry.io/collector/extension"
 )
 
-// StsSettingsProvider is the interface for components that provide dynamic StackState (internal) settings.
+// StsSettingsProvider is the main interface that components and subscribers depend on for access to Stack settings.
+//
+// It intentionally does not expose direct access to raw settings because:
+//   - Different setting types have different concrete Go types, which is tricky to encapsulate behind a single type-safe method.
+//   - Go interfaces cannot express a generic method signature like
+//     SafeGetCurrentSettingsByType[T any](typ SettingType) ([]T, error).
+//
+// Instead, providers must also implement the internal
+// InternalRawSettingsProvider interface, which exposes an untyped
+// `UnsafeGetCurrentSettingsByType`. Consumers should not call this
+// directly.
+//
+// To retrieve settings as a concrete type, use the generic helper
+// function GetSettingsAs[T], which performs the unsafe cast internally
+// and returns a type-safe slice to the caller.
 type StsSettingsProvider interface {
 	extension.Extension
 
@@ -15,19 +29,44 @@ type StsSettingsProvider interface {
 	RegisterForUpdates(types ...stsSettingsModel.SettingType) <-chan stsSettingsEvents.UpdateSettingsEvent
 	// Unregister allows a subscriber to unregister for further setting changes.
 	Unregister(ch <-chan stsSettingsEvents.UpdateSettingsEvent) bool
-
-	// GetCurrentSettingsByType using as unexported and untyped as a way to define a contract, but it's not what
-	// clients/subscribers should be using because we can't define methods with type parameters on interfaces, e.g.:
-	//  - getCurrentSettingsByType[T any](typ stsSettingsModel.SettingType) ([]T, error)
-	// Instead, subscribers should use the exported typed accessor GetSettingsAs
-	GetCurrentSettingsByType(typ stsSettingsModel.SettingType) ([]any, error) // TODO: don't export?
 }
 
-// GetSettingsAs is a helper to ensure subscribers get compile-time checks and deep copies of settings
+// InternalRawSettingsProvider is an internal interface that makes it explicit that retrieving settings using this interface is not type-safe.
+//
+// This interface exists solely to work around Go's limitation that interfaces cannot have generic methods.
+// All StsSettingsProvider implementations must also implement this interface.
+type InternalRawSettingsProvider interface {
+	// UnsafeGetCurrentSettingsByType returns settings for a given type as []any.
+	//
+	// This method is intentionally untyped and unsafe. Callers should use the
+	// type-safe GetSettingsAs[T] helper function instead of calling this directly.
+	//
+	// Returns an error if the setting type is unknown or if retrieval fails.
+	UnsafeGetCurrentSettingsByType(typ stsSettingsModel.SettingType) ([]any, error)
+}
+
+// GetSettingsAs provides a type-safe way to retrieve settings of a given type
+// from a StsSettingsProvider.
+//
+// This function works around Go's limitation that interfaces cannot have generic methods.
+// Internally, it:
+//  1. Downcasts the provider to InternalRawSettingsProvider
+//  2. Calls the untyped UnsafeGetCurrentSettingsByType method
+//  3. Casts and copies the results into a type-safe []T slice
+//
+// All StsSettingsProvider implementations must also implement InternalRawSettingsProvider
+// for this function to work.
+//
+// Example usage:
+//
+//	settings, err := GetSettingsAs[OtelComponentMapping](provider, SettingTypeOtelComponentMapping)
+//
+// Returns an error if the setting type is unknown, retrieval fails, or type casting fails.
 func GetSettingsAs[T any](p StsSettingsProvider, typ stsSettingsModel.SettingType) ([]T, error) {
-	settings, err := p.GetCurrentSettingsByType(typ) // returns []any
+	raw := p.(InternalRawSettingsProvider) // all implementations must also satisfy this
+	vals, err := raw.UnsafeGetCurrentSettingsByType(typ)
 	if err != nil {
 		return nil, err
 	}
-	return stsSettingsCore.CastAndCopySlice[T](settings)
+	return stsSettingsCore.CastAndCopySlice[T](vals)
 }

--- a/extension/settingsproviderextension/internal/core/settings_helper.go
+++ b/extension/settingsproviderextension/internal/core/settings_helper.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"github.com/mohae/deepcopy"
 	stsSettingsModel "github.com/stackvista/sts-opentelemetry-collector/connector/tracetotopoconnector/generated/settings"
 )
 
@@ -30,30 +29,16 @@ func ConverterFor(t stsSettingsModel.SettingType) (ConverterFunc, bool) {
 	return fn, ok
 }
 
-func CastAndCopySlice[T any](raw []any) ([]T, error) {
+func CastSlice[T any](raw []any) ([]T, error) {
 	out := make([]T, 0, len(raw))
 	for _, v := range raw {
-		t, ok := v.(T)
+		typed, ok := v.(T)
 		if !ok {
 			return nil, fmt.Errorf("expected element of type %T but got %T", *new(T), v)
 		}
-		typedCopy, err := DeepCopyAs[T](t)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, typedCopy)
+		out = append(out, typed)
 	}
 	return out, nil
-}
-
-func DeepCopyAs[T any](val any) (T, error) {
-	valCopy := deepcopy.Copy(val)
-	typedCopy, ok := valCopy.(T)
-	if !ok {
-		var zero T
-		return zero, fmt.Errorf("failed to cast deepcopy to expected type")
-	}
-	return typedCopy, nil
 }
 
 // GetSettingType returns the SettingType of a generic setting

--- a/extension/settingsproviderextension/internal/core/settings_helper_test.go
+++ b/extension/settingsproviderextension/internal/core/settings_helper_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	stsSettingsModel "github.com/stackvista/sts-opentelemetry-collector/connector/tracetotopoconnector/generated/settings"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -87,24 +86,6 @@ func TestSettingsHelper_GetSettingType(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestSettingsHelper_DeepCopyAs(t *testing.T) {
-	t.Run("struct with nested references", func(t *testing.T) {
-		mapping := newOtelComponentMapping("111")
-
-		mappingCopy, err := DeepCopyAs[stsSettingsModel.OtelComponentMapping](mapping)
-		require.NoError(t, err)
-
-		// Values match
-		require.Equal(t, mapping, mappingCopy)
-
-		// Slices are not the same reference
-		require.NotSame(t, mapping.Conditions, mappingCopy.Conditions)
-
-		// Nested pointer fields also independent
-		require.NotSame(t, &mapping.Output.DomainIdentifier, &mappingCopy.Output.DomainIdentifier)
-	})
 }
 
 func newOtelComponentMapping(id string) stsSettingsModel.OtelComponentMapping {

--- a/extension/settingsproviderextension/internal/provider/file/file_settings_provider.go
+++ b/extension/settingsproviderextension/internal/provider/file/file_settings_provider.go
@@ -117,7 +117,8 @@ func (f *SettingsProvider) Unregister(ch <-chan stsSettingsEvents.UpdateSettings
 	return f.settingsCache.Unregister(ch)
 }
 
-func (f *SettingsProvider) GetCurrentSettingsByType(settingType stsSettingsModel.SettingType) ([]any, error) {
+// UnsafeGetCurrentSettingsByType implements the internal interface (InternalRawSettingsProvider in api.go)
+func (f *SettingsProvider) UnsafeGetCurrentSettingsByType(settingType stsSettingsModel.SettingType) ([]any, error) {
 	return f.settingsCache.GetConcreteSettingsByType(settingType)
 }
 

--- a/extension/settingsproviderextension/internal/provider/file/file_settings_provider_test.go
+++ b/extension/settingsproviderextension/internal/provider/file/file_settings_provider_test.go
@@ -22,7 +22,7 @@ func TestFileSettingsProvider_NewFileSettingsProvider(t *testing.T) {
 		provider, err := NewFileSettingsProvider(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
 		assert.NotNil(t, provider)
-		settings, err := provider.GetCurrentSettingsByType(stsSettingsModel.SettingTypeOtelComponentMapping)
+		settings, err := provider.UnsafeGetCurrentSettingsByType(stsSettingsModel.SettingTypeOtelComponentMapping)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(settings))
 	})

--- a/extension/settingsproviderextension/internal/provider/kafka/kafka_settings_provider.go
+++ b/extension/settingsproviderextension/internal/provider/kafka/kafka_settings_provider.go
@@ -95,7 +95,8 @@ func (k *SettingsProvider) Unregister(ch <-chan stsSettingsEvents.UpdateSettings
 	return k.settingsCache.Unregister(ch)
 }
 
-func (k *SettingsProvider) GetCurrentSettingsByType(settingType stsSettingsModel.SettingType) ([]any, error) {
+// UnsafeGetCurrentSettingsByType implements the internal interface (InternalRawSettingsProvider in api.go)
+func (k *SettingsProvider) UnsafeGetCurrentSettingsByType(settingType stsSettingsModel.SettingType) ([]any, error) {
 	return k.settingsCache.GetConcreteSettingsByType(settingType)
 }
 


### PR DESCRIPTION
Overview of changes:
- use internal interface to encapsulate unsafe get settings method - provides a level of indirection and makes it clear that it shouldn't be used (from a client perspective, an explicit cast to `InternalRawSettingsProvider` needs to be made). 
- move the deep copy to the private get settings helper on the SettingsByType type to ensure there are no accidental leaks of mutable Concrete types being returned