### PR TITLE
STAC-0: bump base image to distroless static-debian12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN go install go.opentelemetry.io/collector/cmd/builder@v0.100.0
 RUN builder --config ./sts-otel-builder.yaml
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian12
 USER 10001
 COPY --from=builder /go/src/github.com/stackvista/sts-opentelemetry-collector/bin/sts-opentelemetry-collector /usr/bin/sts-opentelemetry-collector
 ENTRYPOINT ["/usr/bin/sts-opentelemetry-collector"]


### PR DESCRIPTION
Since Debian 13 is out Debian 11 is a pretty old base image to base our container on.

I felt like bumping to Debian 12 was due :-)