### PR TITLE
STAC-23296: stskafkaexporter | add configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ docker build . -t sts-opentelemetry-collector:latest
 ## Run it locally 
 Create a file (`dev-config.yaml`) with configuration for OpenTelemetry Collector.
 ```yaml
-connectors:
-  tracetotopo:
-
 receivers:
   otlp:
     protocols:

--- a/exporter/stskafkaexporter/example/sts_kafka_exporter.md
+++ b/exporter/stskafkaexporter/example/sts_kafka_exporter.md
@@ -1,0 +1,37 @@
+# STS Kafka Exporter
+
+Example configuration:
+```yaml
+exporters:
+  stskafkaexporter:
+    brokers: [ "localhost:9092" ]
+    topic: "sts-otel-topology" 
+    read_timeout: 2s
+    produce_timeout: 5s
+    required_acks: "none"   # allowed: "none", "leader", "all"
+
+    # The configuration below is for the exporterhelper (which wraps the custom kafka exporter):
+    
+    # Configuration for internal queueing batches before sending to the kafka exporter
+    sending_queue:
+      enabled: true
+      num_consumers: 1
+      queue_size: 5000
+      
+    # Configuration for retrying batches in case of export failure
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+
+    # The timeout applies to individual attempts to send data to the backend (kafka exporter). Zero means no timeout.
+    timeout: 30s
+
+service:
+  pipelines:
+    logs:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ stskafkaexporter ]
+```

--- a/exporter/stskafkaexporter/exporter.go
+++ b/exporter/stskafkaexporter/exporter.go
@@ -84,13 +84,13 @@ func requiredAcksFromConfig(val string) []kgo.Opt {
 }
 
 func (e *KafkaExporter) Start(ctx context.Context, _ component.Host) error {
-	e.logger.Info("Starting Kafka settings provider",
+	e.logger.Info("Starting STS Kafka exporter",
 		zap.Strings("brokers", e.cfg.Brokers),
 		zap.String("topic", e.cfg.Topic))
 
 	// Fail fast: check if topic exists
 	if err := e.checkTopicExists(ctx); err != nil {
-		return fmt.Errorf("failed to Start kafka settings provider: %w", err)
+		return fmt.Errorf("failed to Start STS Kafka exporter: %w", err)
 	}
 
 	return nil

--- a/exporter/stskafkaexporter/exporter_integration_test.go
+++ b/exporter/stskafkaexporter/exporter_integration_test.go
@@ -67,7 +67,7 @@ func setupTest(t *testing.T) *testContext {
 	brokers, err := kafkaContainer.Brokers(ctx)
 	require.NoError(t, err)
 
-	topicName := fmt.Sprintf("sts-internal-settings-%s", uuid.New().String())
+	topicName := fmt.Sprintf("sts-otel-topology-%s", uuid.New().String())
 	createTopic(t, brokers, topicName)
 
 	// Create exporter

--- a/exporter/stskafkaexporter/factory.go
+++ b/exporter/stskafkaexporter/factory.go
@@ -47,7 +47,7 @@ func CreateDefaultConfig() component.Config {
 		QueueSettings:   queueSettings,
 
 		Brokers:        []string{"localhost:9092"},
-		Topic:          "otel-topology-stream",
+		Topic:          "sts-otel-topology",
 		ReadTimeout:    2 * time.Second,
 		ProduceTimeout: 5 * time.Second,
 		RequiredAcks:   "leader",

--- a/extension/settingsproviderextension/example/settings_provider_extension.md
+++ b/extension/settingsproviderextension/example/settings_provider_extension.md
@@ -18,12 +18,12 @@ The commands below are assuming they'll be run from the root dir of the project.
 The following Compose app will also take care of creating a Kafka topic called `sts-internal-settings`.
 
 ```shell
-docker-compose -f docker/kafka/docker-compose.yaml up -d
+docker-compose -f ./extension/settingsproviderextension/example/docker-compose.yaml up -d
 ```
 
 To stop the Compose app when you're done:
 ```shell
-docker-compose -f docker/kafka/docker-compose down
+docker-compose -f ./extension/settingsproviderextension/example/docker-compose.yaml down
 ```
 
 ### Run the collector using config with extension enabled

--- a/sts-otel-builder.yaml
+++ b/sts-otel-builder.yaml
@@ -19,6 +19,8 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.100.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.100.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.100.0
+  - gomod: github.com/stackvista/sts-opentelemetry-collector/exporter/stskafkaexporter v0.0.0
+    path: ./exporter/stskafkaexporter
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.100.0


### PR DESCRIPTION
Changes summary:
- add stskafkaexporter to otel-builder config
- config example for the exporter 