### PR TITLE
STAC-0: enable linting errors in CI as critical

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: golangci-lint ${{ matrix.modules }}
         uses: golangci/golangci-lint-action@v8
-        continue-on-error: true
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ${{ matrix.modules }}

--- a/connector/tracetotopoconnector/config_test.go
+++ b/connector/tracetotopoconnector/config_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage
 package tracetotopoconnector
 
 import (

--- a/connector/tracetotopoconnector/factory_test.go
+++ b/connector/tracetotopoconnector/factory_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage
 package tracetotopoconnector
 
 import (

--- a/exporter/stskafkaexporter/exporter.go
+++ b/exporter/stskafkaexporter/exporter.go
@@ -207,9 +207,9 @@ func extractKey(attrs pcommon.Map) ([]byte, error) {
 // extractValue retrieves the message body from the plog.LogRecord.
 func (e *KafkaExporter) extractValue(lr plog.LogRecord) ([]byte, error) {
 	body := lr.Body()
-	switch body.Type() {
-	case pcommon.ValueTypeBytes:
-		// Clone to avoid aliasing shared memory.
+
+	//nolint:exhaustive,gocritic
+	if body.Type() == pcommon.ValueTypeBytes {
 		return append([]byte(nil), body.Bytes().AsRaw()...), nil
 	}
 	return nil, errors.New("unsupported log record body type")

--- a/extension/settingsproviderextension/internal/core/cache.go
+++ b/extension/settingsproviderextension/internal/core/cache.go
@@ -133,6 +133,7 @@ func (s *DefaultSettingsCache) UpdateSettingsForType(
 	// Convert all new entries to concrete type first
 	if converter, ok := ConverterFor(settingType); ok {
 		for _, entry := range newEntries {
+			//nolint:gosec
 			_, err := s.toConcreteTypeIfNeeded(&entry, converter)
 			if err != nil {
 				s.logger.Warn(


### PR DESCRIPTION
Just fixing the few remaining errors and then enabling the linting as a red circle in the CI :+1: 