### PR TITLE
STAC-23152: swap sync.Map with expirable.LRU

### DIFF
--- a/connector/tracetotopoconnector/config.go
+++ b/connector/tracetotopoconnector/config.go
@@ -1,5 +1,41 @@
 package tracetotopoconnector
 
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	defaultCacheSize = 1000
+	maxCacheSize     = 20000
+	defaultCacheTTL  = 30 * time.Minute
+)
+
 // Config defines the configuration options for tracetotopoconnector.
 type Config struct {
+	ExpressionCacheSettings ExpressionCacheSettings `mapstructure:"expression_cache_settings"`
+}
+
+type ExpressionCacheSettings struct {
+	Size int           `mapstructure:"size"`
+	TTL  time.Duration `mapstructure:"ttl"`
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.ExpressionCacheSettings.Size <= 0 {
+		cfg.ExpressionCacheSettings.Size = defaultCacheSize
+	} else if cfg.ExpressionCacheSettings.Size > maxCacheSize {
+		return fmt.Errorf("expression_cache.size exceeds max allowed (%d)", maxCacheSize)
+	}
+
+	if cfg.ExpressionCacheSettings.TTL <= 0 {
+		// no value provided, using the default
+		cfg.ExpressionCacheSettings.TTL = defaultCacheTTL
+	} else if cfg.ExpressionCacheSettings.TTL <= time.Duration(100) {
+		// Guard against hashicorp/golang-lru bug with expiry buckets (ttl/100 == 0 result in a panic in the Ticker).
+		// Must be strictly greater than 100ns.
+		return fmt.Errorf("parameter expression_cache.ttl must be a positive value greater than 100ns")
+	}
+
+	return nil
 }

--- a/connector/tracetotopoconnector/config_test.go
+++ b/connector/tracetotopoconnector/config_test.go
@@ -1,0 +1,97 @@
+package tracetotopoconnector
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_Validation(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *Config
+		wantErr    string
+		wantSize   int
+		wantTTLMin time.Duration
+	}{
+		{
+			name: "valid config",
+			cfg: &Config{
+				ExpressionCacheSettings: ExpressionCacheSettings{
+					Size: 1000,
+					TTL:  10 * time.Minute,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "apply default size if not set",
+			cfg: &Config{
+				ExpressionCacheSettings: ExpressionCacheSettings{
+					Size: 0,
+					TTL:  10 * time.Minute,
+				},
+			},
+			wantErr:  "",
+			wantSize: defaultCacheSize,
+		},
+		{
+			name: "return error if size exceeds max",
+			cfg: &Config{
+				ExpressionCacheSettings: ExpressionCacheSettings{
+					Size: maxCacheSize + 1,
+					TTL:  10 * time.Minute,
+				},
+			},
+			wantErr: fmt.Sprintf("expression_cache.size exceeds max allowed (%d)", maxCacheSize),
+		},
+		{
+			name: "apply default ttl if not set",
+			cfg: &Config{
+				ExpressionCacheSettings: ExpressionCacheSettings{
+					Size: 100,
+					TTL:  0,
+				},
+			},
+			wantErr:    "",
+			wantTTLMin: defaultCacheTTL,
+		},
+		{
+			name: "return error if ttl is too small",
+			cfg: &Config{
+				ExpressionCacheSettings: ExpressionCacheSettings{
+					Size: 100,
+					TTL:  50, // <= 100ns
+				},
+			},
+			wantErr: "parameter expression_cache.ttl must be a positive value greater than 100ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Check size normalization
+			if tt.wantSize > 0 {
+				assert.Equal(t, tt.wantSize, tt.cfg.ExpressionCacheSettings.Size)
+			}
+
+			// Check ttl normalization
+			if tt.wantTTLMin > 0 {
+				assert.Equal(t, tt.wantTTLMin, tt.cfg.ExpressionCacheSettings.TTL)
+			}
+		})
+	}
+}

--- a/connector/tracetotopoconnector/connector.go
+++ b/connector/tracetotopoconnector/connector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -17,16 +16,18 @@ import (
 )
 
 type connectorImpl struct {
+	cfg              *Config
 	logger           *zap.Logger
 	logsConsumer     consumer.Logs
 	settingsProvider stsSettingsApi.StsSettingsProvider
 	subscriptionCh   <-chan stsSettingsEvents.UpdateSettingsEvent
 }
 
-func newConnector(logger *zap.Logger, _ component.Config, nextConsumer consumer.Logs) *connectorImpl {
+func newConnector(cfg Config, logger *zap.Logger, nextConsumer consumer.Logs) *connectorImpl {
 	logger.Info("Building tracetotopo connector")
 
 	return &connectorImpl{
+		cfg:          &cfg,
 		logger:       logger,
 		logsConsumer: nextConsumer,
 	}

--- a/connector/tracetotopoconnector/factory.go
+++ b/connector/tracetotopoconnector/factory.go
@@ -2,6 +2,8 @@ package tracetotopoconnector
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
@@ -23,7 +25,12 @@ func NewFactory() connector.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		ExpressionCacheSettings: ExpressionCacheSettings{
+			Size: 1000,
+			TTL:  15 * time.Minute,
+		},
+	}
 }
 
 func createTracesToLogsConnector(
@@ -32,5 +39,10 @@ func createTracesToLogsConnector(
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (connector.Traces, error) {
-	return newConnector(params.Logger, cfg, nextConsumer), nil
+	typedCfg, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type: %T", cfg)
+	}
+
+	return newConnector(*typedCfg, params.Logger, nextConsumer), nil
 }

--- a/connector/tracetotopoconnector/factory_test.go
+++ b/connector/tracetotopoconnector/factory_test.go
@@ -1,0 +1,13 @@
+package tracetotopoconnector
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"testing"
+)
+
+func TestFactory_CreateDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig()
+	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+	assert.NotNil(t, cfg)
+}

--- a/connector/tracetotopoconnector/internal/expression.go
+++ b/connector/tracetotopoconnector/internal/expression.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"errors"
 	"fmt"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/stackvista/sts-opentelemetry-collector/connector/tracetotopoconnector"
@@ -350,12 +349,7 @@ func (e *CelEvaluator) evalOrCached(expression string, expressionKind expression
 func (e *CelEvaluator) getOrCompile(original string, kind expressionKind) (cel.Program, error) {
 	// check cache by original expression
 	if prog, ok := e.cache.Get(original); ok {
-		ownedProgram, ok := prog.(cel.Program)
-		if !ok {
-			return nil, errors.New("unable to cast program to owned program")
-		}
-
-		return ownedProgram, nil
+		return prog, nil
 	}
 
 	// preprocess based on kind

--- a/connector/tracetotopoconnector/internal/expression_test.go
+++ b/connector/tracetotopoconnector/internal/expression_test.go
@@ -2,11 +2,13 @@
 package internal
 
 import (
+	"github.com/stackvista/sts-opentelemetry-collector/connector/tracetotopoconnector"
 	"github.com/stackvista/sts-opentelemetry-collector/extension/settingsproviderextension/generated/settings"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"strings"
 	"testing"
+	"time"
 )
 
 func makeContext() ExpressionEvalContext {
@@ -43,7 +45,7 @@ func makeContext() ExpressionEvalContext {
 }
 
 func TestEvalStringExpression(t *testing.T) {
-	eval, err := NewCELEvaluator()
+	eval, err := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 	require.NoError(t, err)
 
 	ctx := makeContext()
@@ -146,7 +148,7 @@ func TestEvalStringExpression(t *testing.T) {
 }
 
 func TestEvalBooleanExpression(t *testing.T) {
-	eval, err := NewCELEvaluator()
+	eval, err := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 	require.NoError(t, err)
 
 	ctx := makeContext()
@@ -219,7 +221,7 @@ func TestEvalBooleanExpression(t *testing.T) {
 }
 
 func TestEvalOptionalStringExpression(t *testing.T) {
-	eval, err := NewCELEvaluator()
+	eval, err := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 	require.NoError(t, err)
 
 	ctx := makeContext()
@@ -251,7 +253,7 @@ func TestEvalOptionalStringExpression(t *testing.T) {
 }
 
 func TestBoolEvalTypeMismatch(t *testing.T) {
-	eval, _ := NewCELEvaluator()
+	eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 	ctx := makeContext()
 
 	// String expression but evaluated with boolean
@@ -260,7 +262,7 @@ func TestBoolEvalTypeMismatch(t *testing.T) {
 }
 
 func TestStringEvalTypeMismatch(t *testing.T) {
-	eval, _ := NewCELEvaluator()
+	eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 	ctx := makeContext()
 
 	// Bool expression but evaluated with string
@@ -269,7 +271,7 @@ func TestStringEvalTypeMismatch(t *testing.T) {
 }
 
 func TestEvalCacheReuse(t *testing.T) {
-	eval, _ := NewCELEvaluator()
+	eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 	ctx := makeContext()
 
 	expr := settings.OtelBooleanExpression{Expression: `spanAttributes["retries"] == 2`}
@@ -287,6 +289,44 @@ func TestEvalCacheReuse(t *testing.T) {
 	_, err = eval.EvalBooleanExpression(other, &ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, eval.cacheSize())
+}
+
+func TestEvalCacheEvictionBySize(t *testing.T) {
+	// very small cache to force eviction
+	eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 2, TTL: 1 * time.Minute})
+	ctx := makeContext()
+
+	exprs := []settings.OtelBooleanExpression{
+		{Expression: `spanAttributes["retries"] == 1`},
+		{Expression: `spanAttributes["retries"] == 2`},
+		{Expression: `spanAttributes["retries"] == 3`}, // this should evict one of the earlier ones
+	}
+
+	for _, e := range exprs {
+		_, err := eval.EvalBooleanExpression(e, &ctx)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 2, eval.cacheSize()) // capped by size
+}
+
+func TestEvalCacheExpiryByTTL(t *testing.T) {
+	// short TTL so entries expire quickly
+	eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 10, TTL: 200 * time.Millisecond})
+	ctx := makeContext()
+
+	expr := settings.OtelBooleanExpression{Expression: `spanAttributes["http.method"] == "GET"`}
+
+	_, err := eval.EvalBooleanExpression(expr, &ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, eval.cacheSize()) // compiled once
+
+	// wait until the TTL expires
+	time.Sleep(300 * time.Millisecond)
+
+	_, err = eval.EvalBooleanExpression(expr, &ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, eval.cacheSize()) // still 1, but it was recompiled after expiry
 }
 
 func TestValidateInterpolation(t *testing.T) {

--- a/connector/tracetotopoconnector/internal/mapping_test.go
+++ b/connector/tracetotopoconnector/internal/mapping_test.go
@@ -3,9 +3,11 @@ package internal
 
 import (
 	"errors"
+	"github.com/stackvista/sts-opentelemetry-collector/connector/tracetotopoconnector"
 	"github.com/stackvista/sts-opentelemetry-collector/extension/settingsproviderextension/generated/settings"
 	"sort"
 	"testing"
+	"time"
 
 	topo_stream_v1 "github.com/stackvista/sts-opentelemetry-collector/connector/tracetotopoconnector/generated/topostream/topo_stream.v1"
 	"github.com/stretchr/testify/assert"
@@ -149,7 +151,7 @@ func TestMapping_MapComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			eval, _ := NewCELEvaluator()
+			eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 			evalCtx := ExpressionEvalContext{*tt.span, *tt.scope, *tt.resource, *tt.vars}
 			got, err := MapComponent(tt.mapping, eval, &evalCtx)
 			assert.Equal(t, errorStrings(tt.expectErr), errorStrings(err))
@@ -235,7 +237,7 @@ func TestMapping_MapRelation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			eval, _ := NewCELEvaluator()
+			eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 			evalCtx := ExpressionEvalContext{*tt.span, *tt.scope, *tt.resource, *tt.vars}
 			got, err := MapRelation(tt.mapping, eval, &evalCtx)
 			assert.Equal(t, errorStrings(tt.expectErr), errorStrings(err))

--- a/connector/tracetotopoconnector/internal/pipeline_test.go
+++ b/connector/tracetotopoconnector/internal/pipeline_test.go
@@ -2,6 +2,7 @@
 package internal
 
 import (
+	"github.com/stackvista/sts-opentelemetry-collector/connector/tracetotopoconnector"
 	"sort"
 	"testing"
 	"time"
@@ -336,7 +337,7 @@ func TestPipeline_ConvertSpanToTopologyStreamMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			eval, _ := NewCELEvaluator()
+			eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 			result := ConvertSpanToTopologyStreamMessage(eval, traces, tt.componentMappings, tt.relationMappings, now)
 			unify(&result)
 			//nolint:gosec
@@ -354,7 +355,7 @@ func TestPipeline_ConvertSpanToTopologyStreamMessage(t *testing.T) {
 			createSimpleRelationMapping("rm1"),
 			createSimpleRelationMapping("rm2"),
 		}
-		eval, _ := NewCELEvaluator()
+		eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 		result := ConvertSpanToTopologyStreamMessage(eval, traces, componentMappings, relationMappings, now)
 		actualKeys := make([]topo_stream_v1.TopologyStreamMessageKey, 0)
 		for _, message := range result {
@@ -420,7 +421,7 @@ func TestPipeline_ConvertSpanToTopologyStreamMessage(t *testing.T) {
 		relationMappings := []settings.OtelRelationMapping{
 			createSimpleRelationMapping("rm1"),
 		}
-		eval, _ := NewCELEvaluator()
+		eval, _ := NewCELEvaluator(tracetotopoconnector.ExpressionCacheSettings{Size: 100, TTL: 30 * time.Second})
 		result := ConvertSpanToTopologyStreamMessage(eval, traceWithSpans, componentMappings, relationMappings, now)
 		actualKeys := make([]topo_stream_v1.TopologyStreamMessageKey, 0)
 		for _, message := range result {


### PR DESCRIPTION
Changes overview: 
- swamp unbounded sync.Map (expression -> cel.Program) cache with expirable.LRU (bounded and thread-safe as well)
- config object with accompanying test