### PR TITLE
STAC-0: pin protoc-gen-go version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install protoc # TODO create a docker image with protoc installed
         run: |
           sudo apt-get install -y protobuf-compiler
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.8
       - name: Generate go model
         env:
           GITLAB_READ_TOKEN: ${{ secrets.GITLAB_READ_TOKEN }}


### PR DESCRIPTION
We wanna prevent the build from failing due to newer versions of protoc-gen-go just being released.

Thanks @deontaljaard!