### PR TITLE
STAC-0: remove redundant setting type from public setting api

### DIFF
--- a/connector/tracetotopoconnector/connector.go
+++ b/connector/tracetotopoconnector/connector.go
@@ -126,14 +126,14 @@ func (p *connectorImpl) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 
 // updateMappings updates the mappings from the settings provider
 func (p *connectorImpl) updateMappings() {
-	if componentMappings, err := stsSettingsApi.GetSettingsAs[stsSettingsModel.OtelComponentMapping](p.settingsProvider,
-		stsSettingsModel.SettingTypeOtelComponentMapping); err != nil {
+	componentMappings, err := stsSettingsApi.GetSettingsAs[stsSettingsModel.OtelComponentMapping](p.settingsProvider)
+	if err != nil {
 		p.logger.Error("failed to get component mappings", zap.Error(err))
 	} else {
 		atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&p.componentMappings)), unsafe.Pointer(&componentMappings))
 	}
-	if relationMappings, err := stsSettingsApi.GetSettingsAs[stsSettingsModel.OtelRelationMapping](p.settingsProvider,
-		stsSettingsModel.SettingTypeOtelRelationMapping); err != nil {
+	relationMappings, err := stsSettingsApi.GetSettingsAs[stsSettingsModel.OtelRelationMapping](p.settingsProvider)
+	if err != nil {
 		p.logger.Error("failed to get relation mappings", zap.Error(err))
 	} else {
 		atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&p.relationMappings)), unsafe.Pointer(&relationMappings))

--- a/connector/tracetotopoconnector/connector_test.go
+++ b/connector/tracetotopoconnector/connector_test.go
@@ -256,7 +256,7 @@ func (m *mockStsSettingsProvider) UnsafeGetCurrentSettingsByType(typ settings.Se
 	case settings.SettingTypeOtelRelationMapping:
 		return toAnySlice(m.relationMappings), nil
 	default:
-		return nil, errors.New("Not supported type of settings")
+		return nil, errors.New("not supported type of settings")
 	}
 }
 

--- a/extension/settingsproviderextension/generated/settings/extensions.go
+++ b/extension/settingsproviderextension/generated/settings/extensions.go
@@ -1,5 +1,10 @@
 package settings
 
+import (
+	"fmt"
+	"reflect"
+)
+
 // NOTE: these extensions/helpers are not auto-generated
 
 // SizeOfRawSetting returns the size of the underlying raw encoded JSON value.
@@ -30,4 +35,18 @@ func (m OtelRelationMapping) GetId() string {
 
 func (m OtelRelationMapping) GetExpireAfterMs() int64 {
 	return m.ExpireAfterMs
+}
+
+func GetSettingType[T any]() (SettingType, error) {
+	var zero T
+	t := reflect.TypeOf(zero)
+
+	switch t {
+	case reflect.TypeOf(OtelComponentMapping{}):
+		return SettingTypeOtelComponentMapping, nil
+	case reflect.TypeOf(OtelRelationMapping{}):
+		return SettingTypeOtelRelationMapping, nil
+	default:
+		return "", fmt.Errorf("unsupported type: %s", t.Name())
+	}
 }

--- a/extension/settingsproviderextension/internal/provider/file/file_settings_provider_integration_test.go
+++ b/extension/settingsproviderextension/internal/provider/file/file_settings_provider_integration_test.go
@@ -25,7 +25,7 @@ func TestFileSettingsProvider_LoadsInitialSettings(t *testing.T) {
 	_, cancel, provider, _ := setupFileProvider(t, 100*time.Millisecond)
 	defer cancel()
 
-	currentSettings, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelComponentMapping](provider, stsSettingsModel.SettingTypeOtelComponentMapping)
+	currentSettings, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelComponentMapping](provider)
 	require.NoError(t, err)
 	assert.Len(t, currentSettings, 1, "should have one OtelComponentMapping")
 }
@@ -49,8 +49,7 @@ func TestFileSettingsProvider_DetectsFileChanges(t *testing.T) {
 	// Even though we write the file atomically, the provider may not see the update immediately.
 	// require.Eventually waits until the provider reads the updated file and updates its cache.
 	require.Eventually(t, func() bool {
-		current, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelComponentMapping](
-			provider, stsSettingsModel.SettingTypeOtelComponentMapping)
+		current, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelComponentMapping](provider)
 		if err != nil {
 			return false
 		}

--- a/extension/settingsproviderextension/internal/provider/kafka/kafka_settings_provider_integration_test.go
+++ b/extension/settingsproviderextension/internal/provider/kafka/kafka_settings_provider_integration_test.go
@@ -46,9 +46,9 @@ func TestKafkaSettingsProvider_InitialState(t *testing.T) {
 	relationMapping := publishRelationMapping(t, tc, "22222", "Runs on host")
 	waitForSettingsUpdate[stsSettingsModel.OtelRelationMapping](t, tc, stsSettingsModel.SettingTypeOtelRelationMapping)
 
-	otelComponentMappings, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelComponentMapping](tc.provider, stsSettingsModel.SettingTypeOtelComponentMapping)
+	otelComponentMappings, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelComponentMapping](tc.provider)
 	require.NoError(t, err)
-	otelRelationMappings, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelRelationMapping](tc.provider, stsSettingsModel.SettingTypeOtelRelationMapping)
+	otelRelationMappings, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelRelationMapping](tc.provider)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(otelComponentMappings)+len(otelRelationMappings), "Unexpected number of settings")
 	assertComponentMapping(t, otelComponentMappings, componentMapping.id, componentMapping.name)
@@ -75,7 +75,7 @@ func TestKafkaSettingsProvider_Compaction(t *testing.T) {
 	assertComponentMapping(t, otelComponentMappings, updatedMapping.id, updatedMapping.name)
 
 	// Get otel relation mappings again to check that they're the same
-	otelRelationMappings, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelRelationMapping](tc.provider, stsSettingsModel.SettingTypeOtelRelationMapping)
+	otelRelationMappings, err := stsSettings.GetSettingsAs[stsSettingsModel.OtelRelationMapping](tc.provider)
 	require.NoError(t, err)
 	assertRelationMapping(t, otelRelationMappings, relationMapping.id, relationMapping.name)
 }
@@ -156,7 +156,7 @@ func waitForSettingsUpdate[T any](t *testing.T, tc *testContext, settingType sts
 
 	select {
 	case <-ch:
-		as, err := stsSettings.GetSettingsAs[T](tc.provider, settingType)
+		as, err := stsSettings.GetSettingsAs[T](tc.provider)
 		require.NoError(t, err)
 		return as
 	case <-time.After(updateTimeout):


### PR DESCRIPTION
Changes overview:
- add typed `GetSettingType` helper so we can improve API ergonomics - remove redundant setting type parameter on a typed function