### PR TITLE
STAC-25145 Update image-pipeline actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Apply OCI labels
         id: oci-labels
-        uses: StackVista/image-pipeline/.github/actions/apply-oci-labels@1710ed69de6e8e712f7f8c4d61aaa7026249f39c
+        uses: StackVista/image-pipeline/.github/actions/apply-oci-labels@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
         with:
           image-name: ${{ steps.image-name.outputs.value }}
           tag: ${{ steps.meta.outputs.version }}
@@ -157,7 +157,7 @@ jobs:
           docker tag "$loaded" scan-target:${{ matrix.image }}-${{ matrix.arch }}
 
       - name: Run image-pipeline scan-image
-        uses: StackVista/image-pipeline/.github/actions/scan-image@1710ed69de6e8e712f7f8c4d61aaa7026249f39c
+        uses: StackVista/image-pipeline/.github/actions/scan-image@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
         with:
           image: scan-target:${{ matrix.image }}-${{ matrix.arch }}
           mode: gate

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Apply OCI labels
         id: oci-labels
-        uses: StackVista/image-pipeline/.github/actions/apply-oci-labels@d406ce4560d6c9a50e0c8242beeff67e2ee59c62
+        uses: StackVista/image-pipeline/.github/actions/apply-oci-labels@1710ed69de6e8e712f7f8c4d61aaa7026249f39c
         with:
           image-name: ${{ steps.image-name.outputs.value }}
           tag: ${{ steps.meta.outputs.version }}
@@ -157,7 +157,7 @@ jobs:
           docker tag "$loaded" scan-target:${{ matrix.image }}-${{ matrix.arch }}
 
       - name: Run image-pipeline scan-image
-        uses: StackVista/image-pipeline/.github/actions/scan-image@dfbfa39e887dfdce25e185b6fac52e325de811af
+        uses: StackVista/image-pipeline/.github/actions/scan-image@1710ed69de6e8e712f7f8c4d61aaa7026249f39c
         with:
           image: scan-target:${{ matrix.image }}-${{ matrix.arch }}
           mode: gate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 ARG BASE_IMAGE=registry.suse.com/bci/bci-micro:15.7-56.21
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.26 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH
 
-RUN apk add --no-cache git
+RUN zypper --non-interactive refresh \
+    && zypper --non-interactive install --no-recommends git-core \
+    && zypper clean --all \
+    && rm -rf /var/log/zypp /var/log/zypper.log
 
 WORKDIR /go/src/github.com/stackvista/sts-opentelemetry-collector
 COPY . .

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,11 +1,14 @@
 ARG BASE_IMAGE=registry.suse.com/bci/bci-micro:15.7-56.21
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.26 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH
 
-RUN apk add --no-cache git
+RUN zypper --non-interactive refresh \
+    && zypper --non-interactive install --no-recommends git-core \
+    && zypper clean --all \
+    && rm -rf /var/log/zypp /var/log/zypper.log
 
 WORKDIR /go/src/github.com/stackvista/sts-opentelemetry-collector
 COPY . .

--- a/connector/topologyconnector/go.mod
+++ b/connector/topologyconnector/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.59.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/zap v1.28.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )
@@ -85,7 +86,6 @@ require (
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.153.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect

--- a/exporter/stskafkaexporter/go.mod
+++ b/exporter/stskafkaexporter/go.mod
@@ -15,6 +15,8 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper v0.153.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.153.0
 	go.opentelemetry.io/collector/pdata v1.59.0
+	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/zap v1.28.0
 )
 
@@ -61,10 +63,8 @@ require (
 	go.opentelemetry.io/collector/receiver/receivertest v0.153.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.153.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect

--- a/extension/settingsproviderextension/go.mod
+++ b/extension/settingsproviderextension/go.mod
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/collector/extension v1.59.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/zap v1.28.0
 	go.yaml.in/yaml/v3 v3.0.4
 	gopkg.in/yaml.v3 v3.0.1
@@ -40,7 +41,6 @@ require (
 	go.opentelemetry.io/collector/pdata v1.59.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-go = "latest"
+go = "1.26.5"

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -203,11 +203,13 @@ golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
@@ -219,6 +221,7 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 h1:pfIbyB44sWzHiCpRqIen67ZQnVXSfIxWrqUMk1qwODE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
+google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
- update all `StackVista/image-pipeline` action pins to `6284a6fc006a7cc46a7f00d02c50d5f21b117b63`
- replace both Alpine Go builders with `registry.suse.com/bci/golang:1.26`
- move all workspace modules, `go.work`, workflow setup, mise config, and mise lock checksums to Go 1.26.5

Jira: https://stackstate.atlassian.net/browse/STAC-25145

## Validation
- exact Go 1.26.5 unit sweep across all ten workspace test modules
- Zizmor workflow audit
- all server/agent amd64 and arm64 builds are green
- all four image scans are green
- the release/branch publication job is green



## Final merged-pin validation
- rebased onto the current default branch after the parallel STAC-25251 Go/CVE merges
- pins merged `StackVista/image-pipeline` commit `6284a6fc006a7cc46a7f00d02c50d5f21b117b63`
- current-head GitHub Actions workflows are green
