### PR TITLE
STAC-25323: Refresh BCI runtime for collector images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=registry.suse.com/bci/bci-micro:15.7-56.21
+# renovate: datasource=docker depName=registry.suse.com/bci/bci-micro
+ARG BASE_IMAGE=registry.suse.com/bci/bci-micro:15.7-60.5
 
 FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.26 AS builder
 

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=registry.suse.com/bci/bci-micro:15.7-56.21
+# renovate: datasource=docker depName=registry.suse.com/bci/bci-micro
+ARG BASE_IMAGE=registry.suse.com/bci/bci-micro:15.7-60.5
 
 FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.26 AS builder
 


### PR DESCRIPTION
## Summary

- update both collector runtime images from `bci-micro:15.7-56.21` to `15.7-60.5`
- add Renovate Docker datasource metadata for future BCI patch refreshes
- retain the existing multi-arch BCI-only build and separate vulnerability/secret scan gates

Jira: https://stackstate.atlassian.net/browse/STAC-25323

## Validation

- collector unit suite: passed
- local linux/amd64 Docker builds: server and agent passed
- server `components` smoke test: passed
- agent `validate` smoke tests: `scraper.yaml`, `k8s-resource.yaml`, and `telemetry-gateway.yaml` passed
- fresh Trivy vulnerability scan: 0 Critical/High/Medium/Low for both built images
- separate Trivy secret scan: 0 findings for both built images
- fresh Grype scan: 0 Critical/High/Medium/Low for both built images
- BCI runtime manifest and base scans: amd64 and arm64 present and clean in Trivy and Grype

Grype still identifies `GO-2026-5932` as UNKNOWN for `golang.org/x/crypto v0.52.0`. The Go advisory marks the unmaintained `openpgp` subpackages as affected for all versions and provides no fixed version. Neither compiled collector binary contains an OpenPGP package reference, so this is not a patchable blocker for this rebuild.

## Release

After merge, tag `v0.0.51` to publish the replacement server and `-agent` multi-arch images.